### PR TITLE
[feat]: BOJ24060 구현 (재귀)

### DIFF
--- a/Devil_Java/src/main/java/week01_recursion/silver/BOJ24060_jiyun.java
+++ b/Devil_Java/src/main/java/week01_recursion/silver/BOJ24060_jiyun.java
@@ -1,4 +1,78 @@
 package week01_recursion.silver;
 
+import java.io.*;
+import java.util.*;
+
 public class BOJ24060_jiyun {
+    static int N;
+    static int K;
+    static int save_cnt=0;
+    static int[] tmp;
+    static boolean found;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        int[] A = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i=0; i<N; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+
+        tmp = new int[N];
+        merge_sort(A,0,N-1);
+        if (!found) {
+            System.out.println(-1);
+        }
+    }
+
+    static void merge_sort(int[] A, int p, int r) {
+        if (found) return;
+        if (p<r) {
+            int q = (p+r)/2;
+            merge_sort(A,p,q);
+            merge_sort(A,q+1,r);
+            merge(A,p,q,r);
+        }
+    }
+
+    static void merge(int[] A, int p, int q, int r) {
+        if (found) return;
+
+        int i = p;
+        int j = q+1;
+        int t = 0;
+
+        while (i<=q && j <=r) {
+            if (A[i]<=A[j]) {
+                tmp[t++] =  A[i++];
+            }
+            else {
+                tmp[t++] = A[j++];
+            }
+
+        }
+        while (i<=q) {
+            tmp[t++] = A[i++];
+        }
+        while (j<=r) {
+            tmp[t++] = A[j++];
+        }
+        i = p;
+        t = 0;
+
+        while (i<=r) {
+            A[i++] = tmp[t++];
+            save_cnt++;
+            if (save_cnt==K) {
+                System.out.println(A[i-1]);
+                found=true;
+                return;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 💡 문제 풀이 요약
- 문제 요구사항 : 병합 정렬 과정에서 배열 A에 K번째 저장되는 값 출력하기
- 전역 변수 save_cnt로 저장 횟수 세고 save_cnt=k이면 저장된 값 출력하고 종료함, 병합 정렬을 모두 끝낸 후에도 found=false이면 (save_cnt<k) -1 출력하고 종료함 

## ⚙️ 성능 최적화
- found 플래그로 return 
   - k번째 값 출력 이후 불필요한 연산하지않고 종료하기 위해 사용 
   - return;으로 종료하면 현재 함수만 종료되고 상위 호출은 이미 스택에 쌓여있기 때문에 그대로 실행됨 
   - k번째 값 출력 이후 found를 true로 바꾸고 return하면 이후 호출되는 다른 상위 함수들도 첫번째 줄에서 found 조건 확인하고 바로 return함 

- tmp를 전역변수로 선언해서 재사용 
   - 기존에는 각 merge 호출마다 new int[r-p+1]로 tmp 생성했는데 전역변수로 선언해서 tmp 배열을 한번만 생성하여 재사용하는 방식으로 리팩토링함  

- BufferedReader, StringTokenizer 사용 
   - BufferedReader : Scanner보다 훨씬 빠름
   - StringTokenizer : split()보다 훨씬 빠름
   - Scanner, split()은 내부적으로 정규표현식을 이용하기 때문에 속도 느림 