### PR TITLE
[2주차] BOJ16463 - 13일의 금요일

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="c29e7d0e-1984-43ba-a62b-2952acd82987" name="변경" comment="">
-      <change afterPath="$PROJECT_DIR$/Devil_Java/src/main/java/week01_recursion/gold/BOJ5639_dwoong.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -23,7 +22,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="dwoong/week01_BOJ24060" />
+        <entry key="$PROJECT_DIR$" value="joshcho/week01_BOJ24060" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -37,7 +36,7 @@
   <component name="GithubPullRequestsUISettings">{
   &quot;selectedUrlAndAccountId&quot;: {
     &quot;url&quot;: &quot;https://github.com/Devil-Algorithm-Study/Devils_Algorithm.git&quot;,
-    &quot;accountId&quot;: &quot;f796f72d-e72d-467c-b1fa-29ef3633737e&quot;
+    &quot;accountId&quot;: &quot;1590cd78-5171-4f22-be53-83825648b558&quot;
   }
 }</component>
   <component name="ProjectColorInfo">{
@@ -56,7 +55,6 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "dwoong/week01__BOJ5639",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/joshcho/Devils_Algorithm",
     "node.js.detected.package.eslint": "true",
@@ -69,7 +67,7 @@
     "애플리케이션.BOJ24060_joshcho.executor": "Run"
   }
 }]]></component>
-  <component name="RunManager" selected="애플리케이션.BOJ5639_joshcho">
+  <component name="RunManager" selected="Application.BOJ5639_joshcho">
     <configuration name="BOJ24060_joshcho" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="week01.silver.BOJ24060_joshcho" />
       <module name="Devils_Algorithm" />
@@ -96,6 +94,13 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Application.BOJ5639_joshcho" />
+        <item itemvalue="Application.BOJ24060_joshcho" />
+        <item itemvalue="Application.BOJ24060_joshcho" />
+      </list>
+    </recent_temporary>
   </component>
   <component name="SharedIndexes">
     <attachedChunks>
@@ -114,11 +119,8 @@
       <updated>1756857465139</updated>
       <workItem from="1756857466412" duration="4849000" />
       <workItem from="1757220613264" duration="2325000" />
-      <workItem from="1757222960521" duration="10019000" />
-      <workItem from="1757318995423" duration="75000" />
-      <workItem from="1757319091125" duration="272000" />
-      <workItem from="1757319388864" duration="8000" />
-      <workItem from="1757319414659" duration="633000" />
+      <workItem from="1757222960521" duration="11455000" />
+      <workItem from="1757861032873" duration="5952000" />
     </task>
     <servers />
   </component>

--- a/Devil_Java/src/main/java/week02_ExhaustiveSearch/silver/BOJ16463_joshcho.java
+++ b/Devil_Java/src/main/java/week02_ExhaustiveSearch/silver/BOJ16463_joshcho.java
@@ -1,0 +1,43 @@
+package week02.silver;
+
+import java.io.*;
+
+public class BOJ16463_joshcho
+{
+
+    // 윤년 확인 로직
+    static boolean isLeap(int y) {
+        return (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int yearEnd = Integer.parseInt(br.readLine());
+
+        // 요일: 0~6 순서대로 일~토,  2019-01-01은 화요일이므로 첫 선언은 2로 함.
+        int firstDayOfWeek = 2;
+
+        // 배열 크기가 13칸인 이유: 가독성을 높이기 위해 1번~12번 인덱스가 1월~12월과 매칭.
+        // 이 정도로는 메모리 누수 차이 거의 없음
+        int[] DaysOfMonth = {0,31,28,31,30,31,30,31,31,30,31,30,31};
+
+        // sum, count 등 반복문을 돌리면서 누적하는 변수는 for문 밖에서 선언하고 사용.
+        int fridayThirteenCount = 0;
+
+        // 2019년부터 입력한 연도까지 탐색
+        for (int startingYear = 2019; startingYear <= yearEnd; startingYear++) {
+            // 일 년 열두 달 탐색
+            for (int month = 1; month <= 12; month++) {
+                // dayOfWeek13 : 이번 달의 13일은 무슨 요일인가?
+                int dayOfWeek13 = (firstDayOfWeek + 12) % 7;
+                if (dayOfWeek13 == 5) fridayThirteenCount++;
+
+                // 윤년이면 2월 29일로 하고, 아니면 28일 그대로
+                int days = (month == 2 && isLeap(startingYear)) ? 29 : DaysOfMonth[month];
+                firstDayOfWeek = (firstDayOfWeek + days) % 7; // 다음 달 1일의 요일
+            }
+        }
+
+        System.out.println(fridayThirteenCount);
+    }
+}


### PR DESCRIPTION
## ✨ 문제 풀이 요약

- 문제링크: [16463번](https://www.acmicpc.net/problem/16463)
- 2019년 이후로 13일인 금요일이 몇 번 있는지를 세는 알고리즘입니다.
- 윤년 또한 고려를 해야하는 문제입니다.

---

### 문제 요구사항

- 첫째 줄에 정수 N이 입력된다. (2019 ≤ N ≤ 100,000)
- 첫째 줄에 2019년부터 N년까지 누적되는 13일의 금요일의 수를 출력한다.

### 접근 방법

- 문제에서 주어진 힌트를 활용했습니다.
- 2019년 1월 1일은 화요일이다.
- 2월이 29일까지 존재하는 해를 윤년이라고 한다.
- 일반적으로 1월부터 12월은 각각 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31일까지 있다. 
- 윤년인 해에는, 2월이 28일까지가 아닌 29일까지 있다.
- 400의 배수 연도는 윤년이다.
- 400의 배수가 아니면서 100의 배수인 연도는 윤년이 아니다.
- 100의 배수가 아니면서 4의 배수인 연도는 윤년이다. 그 외의 연도는 윤년이 아니다.

### 최종 풀이 설명

- 변수 이름은 최대한 한 눈에 알아보게 풀어서 작성했습니다. 
- 일 년 내 12개월동안 for반복문을 통해서 13일인 금요일이 얼마나 있는지를 카운트했습니다.
- 반복횟수가 정해져있기 때문에 for 반복문을 이용하는 게 더 적합하다고 판단했습니다.

---

## ⚡ 성능 최적화

---

- BuffreredReader 를 사용해서 Scanner보다 좋은 효율을 뽑아냈습니다.
- 이외의 요소에서는 최적화를 할 부분은 크게 찾지 못했습니다.

---
## 📌 체크리스트

---
- [x] 브랜치 확인하기! 절대 main 브랜치로 push하면 안됩니다 -_-
- [x] 타인의 코드는 절대 수정하지 않기!