### PR TITLE
[feat]: week02_BOJ16463 13일의 금요일 구현 (완전탐색)

### DIFF
--- a/Devil_Java/src/main/java/week02_bruteforce/BOJ16463_jiyun.java
+++ b/Devil_Java/src/main/java/week02_bruteforce/BOJ16463_jiyun.java
@@ -1,4 +1,65 @@
 package week02_bruteforce;
 
+import java.io.*;
+
 public class BOJ16463_jiyun {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int year = 2019;
+        int last_month = 1;
+        int cnt = 0;
+
+        // 2019.01.13 = 일요일
+        // 일월화수목금토 0123456
+        int dayOfWeek = 0;
+
+        while (year <= n) {
+
+            // java 14 이상 지원
+            int last_month_days = switch(last_month) {
+                case 1,3,5,7,8,10,12 -> 31;
+                case 4,6,9,11 -> 30;
+                default -> check_leaf(year);
+            };
+
+            /* java 11 지원
+            int last_month_days;
+            switch (last_month) {
+                case 1: case 3: case 5: case 7: case 8: case 10: case 12:
+                    last_month_days = 31;
+                    break;
+                case 4: case 6: case 9: case 11:
+                    last_month_days = 30;
+                    break;
+                default:
+                    last_month_days = check_leaf(year);
+                    break;
+            }
+            */
+
+            if (dayOfWeek == 5) {
+                cnt++;
+            }
+
+            dayOfWeek = (dayOfWeek + last_month_days) % 7;
+
+            if (last_month==12) {
+                last_month = 0;
+                year++;
+            }
+
+            last_month++;
+        }
+
+        System.out.println(cnt);
+    }
+
+    static int check_leaf(int year) {
+        if (year%400==0 || (year%100!=0) && (year%4==0)) {
+            return 29;
+        }
+        return 28;
+    }
 }


### PR DESCRIPTION
## ✨ 문제 풀이 요약
- 2019년부터 N년까지 13일이 금요일인 횟수 출력 
---

### 접근 방법
- 2019.01.13은 일요일이므로 2월부터 구하기 
- 요일을 0~6 (일~토)로 표현 
- dayOfWeek = (dayOfWeek + last_month_days) % 7로 다음 달 13일의 요일을 계산 
- 윤년 여부는 check_leaf(year) 메서드로 판단 
- 12월이면 다음 해로 넘어가고 last_month 초기화 

---

## ⚡ 성능 최적화

---

- 

---
## 📌 체크리스트

---
- [ ] 브랜치 확인하기! 절대 main 브랜치로 push하면 안됩니다 -_-
- [ ] 타인의 코드는 절대 수정하지 않기!