### PR TITLE
[feat] Jiyun/week02 boj12100

### DIFF
--- a/Devil_Java/src/main/java/week02_bruteforce/BOJ12100_jiyun.java
+++ b/Devil_Java/src/main/java/week02_bruteforce/BOJ12100_jiyun.java
@@ -1,4 +1,185 @@
 package week02_bruteforce;
 
+import java.io.*;
+import java.util.*;
+
 public class BOJ12100_jiyun {
+
+    static String[] direcction = {"up", "down", "right", "left"};
+    static int n;
+    static int max;
+    static boolean found = false;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        n = Integer.parseInt(br.readLine());
+
+        int[][] graph = new int[n][n];
+
+        for (int i=0; i<n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j=0; j<n; j++) {
+                graph[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dfs(graph, 0);
+        System.out.println(max);
+
+    }
+
+    static void dfs(int[][] graph, int depth) {
+
+        if (depth == 5) {
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    max = Math.max(max, graph[i][j]);
+                }
+            }
+            return;
+        }
+
+        for (String d : direcction) {
+            int[][] copy_graph = new int[n][n];
+            for (int j = 0; j < n; j++) {
+                System.arraycopy(graph[j], 0, copy_graph[j], 0, n);
+            }
+
+//            switch (d) {
+//                case "up" -> move_up(copy_graph);
+//                case "down" -> move_down(copy_graph);
+//                case "left" -> move_left(copy_graph);
+//                default -> move_right(copy_graph);
+//            }
+
+            switch (d) {
+                case "up":
+                    move_up(copy_graph); break;
+                case "down":
+                    move_down(copy_graph); break;
+                case "left":
+                    move_left(copy_graph); break;
+                case "right":
+                    move_right(copy_graph); break;
+            }
+
+            dfs(copy_graph, depth + 1);
+        }
+
+    }
+
+    static void move_up(int[][] copy_graph) {
+        for (int y = 0; y<n; y++) {
+            int writeX = 0;
+            int prev = 0;
+
+            for (int x=0; x<n; x++) {
+                if (copy_graph[x][y]!=0) {
+                    if (prev==0) {
+                        prev = copy_graph[x][y];
+                    }
+                    else if (prev == copy_graph[x][y]) {
+                        copy_graph[writeX++][y] = prev*2;
+                        prev = 0;
+                    }
+                    else {
+                        copy_graph[writeX++][y] = prev;
+                        prev = copy_graph[x][y];
+                    }
+                    copy_graph[x][y] = 0;
+                }
+            }
+
+            if (prev!=0) {
+                copy_graph[writeX][y] = prev;
+            }
+        }
+    }
+
+    static void move_down(int[][] copy_graph) {
+        for (int y = 0; y<n; y++) {
+            int writeX = n-1;
+            int prev = 0;
+
+            for (int x=n-1; x>=0; x--) {
+                if (copy_graph[x][y]!=0) {
+                    if (prev==0) {
+                        prev = copy_graph[x][y];
+                    }
+                    else if (prev == copy_graph[x][y]) {
+                        copy_graph[writeX--][y] = prev*2;
+                        prev = 0;
+                    }
+                    else {
+                        copy_graph[writeX--][y] = prev;
+                        prev = copy_graph[x][y];
+                    }
+                    copy_graph[x][y] = 0;
+                }
+            }
+
+            if (prev!=0) {
+                copy_graph[writeX][y] = prev;
+            }
+        }
+    }
+
+    static void move_left(int[][] copy_graph) {
+        for (int x=0; x<n; x++) {
+            int writeY = 0;
+            int prev = 0;
+
+            for (int y=0; y<n; y++) {
+                if (copy_graph[x][y]!=0) {
+                    if (prev==0) {
+                        prev = copy_graph[x][y];
+                    }
+                    else if (prev == copy_graph[x][y]) {
+                        copy_graph[x][writeY++] = prev*2;
+                        prev = 0;
+                    }
+                    else {
+                        copy_graph[x][writeY++] = prev;
+                        prev = copy_graph[x][y];
+                    }
+                    copy_graph[x][y] = 0;
+                }
+            }
+
+            if (prev!=0) {
+                copy_graph[x][writeY] = prev;
+            }
+        }
+    }
+    static void move_right(int[][] copy_graph) {
+        for (int x=0; x<n; x++) {
+            int writeY = n-1;
+            int prev = 0;
+
+            for (int y=n-1; y>=0; y--) {
+                if (copy_graph[x][y]!=0) {
+                    if (prev==0) {
+                        prev = copy_graph[x][y];
+                    }
+                    else if (prev == copy_graph[x][y]) {
+                        copy_graph[x][writeY--] = prev*2;
+                        prev = 0;
+                    }
+                    else {
+                        copy_graph[x][writeY--] = prev;
+                        prev = copy_graph[x][y];
+                    }
+                    copy_graph[x][y] = 0;
+                }
+            }
+
+            if (prev!=0) {
+                copy_graph[x][writeY] = prev;
+            }
+        }
+
+    }
+
+
 }

--- a/Devil_Java/src/main/java/week02_bruteforce/BOJ12100_jiyun.java
+++ b/Devil_Java/src/main/java/week02_bruteforce/BOJ12100_jiyun.java
@@ -8,7 +8,6 @@ public class BOJ12100_jiyun {
     static String[] direcction = {"up", "down", "right", "left"};
     static int n;
     static int max;
-    static boolean found = false;
 
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -26,11 +25,9 @@ public class BOJ12100_jiyun {
 
         dfs(graph, 0);
         System.out.println(max);
-
     }
 
     static void dfs(int[][] graph, int depth) {
-
         if (depth == 5) {
             for (int i = 0; i < n; i++) {
                 for (int j = 0; j < n; j++) {
@@ -46,23 +43,25 @@ public class BOJ12100_jiyun {
                 System.arraycopy(graph[j], 0, copy_graph[j], 0, n);
             }
 
-//            switch (d) {
-//                case "up" -> move_up(copy_graph);
-//                case "down" -> move_down(copy_graph);
-//                case "left" -> move_left(copy_graph);
-//                default -> move_right(copy_graph);
-//            }
-
+            // java 14+
             switch (d) {
-                case "up":
-                    move_up(copy_graph); break;
-                case "down":
-                    move_down(copy_graph); break;
-                case "left":
-                    move_left(copy_graph); break;
-                case "right":
-                    move_right(copy_graph); break;
+                case "up" -> move_up(copy_graph);
+                case "down" -> move_down(copy_graph);
+                case "left" -> move_left(copy_graph);
+                default -> move_right(copy_graph);
             }
+
+            // java 11
+//            switch (d) {
+//                case "up":
+//                    move_up(copy_graph); break;
+//                case "down":
+//                    move_down(copy_graph); break;
+//                case "left":
+//                    move_left(copy_graph); break;
+//                case "right":
+//                    move_right(copy_graph); break;
+//            }
 
             dfs(copy_graph, depth + 1);
         }


### PR DESCRIPTION
## ✨ 문제 풀이 요약 
- 보드를 최대 5번 상하좌우로 이동시켜 얻을 수 있는 가장 큰 블록 값을 출력 
---

### 접근 방법
- dfs로 깊이 5일때까지 상하좌우 모든 경우의 수 탐색 
   - 깊이=5이면 가장 큰 값 찾아서 출력 
- move_up, move_down, move_left, move_right 4개 메서드 각각 구현 
   - 한줄씩 계산  
   - 0이 아닌 수만 골라서 계산 
   - 같은 숫자가 연속되면 합침 
   - 순서대로 결과를 채워넣음 
  
---

### 트러블 슈팅 
- 처음에 한 번의 이동에서 한 번만 합쳐져야된다는 부분을 빼먹어서 틀림 
-> prev로 이전 블록 값을 저장하고 현재 블록의 값과 같으면 합치고 prev=0으로 초기화
-> prev=0인 상태로 돌아가서 합쳐진 블록은 다시 합쳐지지 않음

---

## ⚡ 성능 최적화
- ArrayList를 사용하면 move 메서드를 방향 1개로 통일할 수 있음 
   -  Collections.reverse(graph)로 방향을 바꾸고 move에 넣어서 처리 가능
- int[][] 배열은 접근/수정이 O(1)로, move를 방향별 4개 메서드를 사용하더라도 속도면에서 더 좋기 때문에 int[][]를 사용함

- System.arraycopy(graph[j], 0, copy_graph[j], 0, n) 사용함 
   - 파라미터 : 원본 배열, 원본 배열 복사 시작 위치, 복사 대상 배열, 대상 배열 복사 시작 위치, 복사할 원소 개수 
   - 깊은 복사라서 원본 값이 바뀌어도 복사본은 바뀌지 않음 
   - for문으로 직접 복사하는 방식보다 속도 빠름 
 
---

- 

---
## 📌 체크리스트

---
- [ ] 브랜치 확인하기! 절대 main 브랜치로 push하면 안됩니다 -_-
- [ ] 타인의 코드는 절대 수정하지 않기!